### PR TITLE
Update ui for devise login

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  before_action :authenticate_user!
+
   def index
   end
 end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,41 @@
+module DeviseHelper
+  def devise_error_messages!
+    return "" unless devise_error_messages?
+
+    parsed_messages = parse_full_error_messages(resource.errors)
+    messages = parsed_messages.map { |msg| content_tag(:li, msg) }.join
+    sentence = I18n.t("errors.messages.not_saved",
+                      :count => resource.errors.count,
+                      :resource => resource.class.model_name.human.downcase)
+
+    html = <<-HTML
+    <div id="error_explanation">
+      <h2>#{sentence}</h2>
+      <ul>#{messages}</ul>
+    </div>
+    HTML
+
+    html.html_safe
+  end
+
+  def devise_error_messages?
+    !resource.errors.empty?
+  end
+
+  private
+
+  def parse_full_error_messages(errors)
+    parsed_messages = []
+    errors.messages.each do |field, messages|
+      messages.each_with_index do |message, index| 
+        if message.try(:chr) == '^'
+          returned_messsage = errors.full_messages_for(field)[index].split('^', 2).last
+        else
+          returned_messsage = errors.full_messages_for(field)[index]
+        end
+        parsed_messages << returned_messsage
+      end
+    end
+    parsed_messages
+  end
+end

--- a/app/javascript/packs/admin/layout.jsx
+++ b/app/javascript/packs/admin/layout.jsx
@@ -20,6 +20,17 @@ const Layout = (props) => {
               <Dropdown.Item as={Link} to="/admins">Admins</Dropdown.Item>
             </Dropdown.Menu>
           </Dropdown>
+          <Menu.Menu position='right'>
+            <Dropdown item text='User'>
+              <Dropdown.Menu>
+                <Dropdown.Item as='a'
+                               href="/admins/sign_out"
+                               data-method="delete">
+                  Sign out
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
+          </Menu.Menu>
         </Menu>
         <Container>
           {

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,7 +1,7 @@
 class Admin < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 
   validates_format_of :email, :with => /\A[^@]+@[^@]+\z/, :message => "^Email format is invalid"

--- a/app/views/admins/confirmations/new.html.erb
+++ b/app/views/admins/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "admins/shared/links" %>

--- a/app/views/admins/mailer/confirmation_instructions.html.erb
+++ b/app/views/admins/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/admins/mailer/password_change.html.erb
+++ b/app/views/admins/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/admins/mailer/reset_password_instructions.html.erb
+++ b/app/views/admins/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/admins/mailer/unlock_instructions.html.erb
+++ b/app/views/admins/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/admins/passwords/edit.html.erb
+++ b/app/views/admins/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "admins/shared/links" %>

--- a/app/views/admins/passwords/new.html.erb
+++ b/app/views/admins/passwords/new.html.erb
@@ -1,0 +1,37 @@
+<div class="ui container">
+  <div class="ui basic very padded segment">
+    <div class="ui grid">
+      <div class="row">
+        <div class="three wide column">
+        </div>
+        <div class="ten wide column">
+          <div class="ui segment">
+
+            <h2>Forgot your password?</h2>
+
+            <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, :class => "ui form" }) do |f| %>
+              <%= devise_error_messages! %>
+
+              <div class="field">
+                <%= f.label :email %>
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+
+              <div class="actions">
+                <%= f.submit "Send me reset password instructions", :class => 'ui button' %>
+              </div>
+            <% end %>
+
+            <div class="ui floated horizontal list">
+              <%= render "admins/shared/links" %>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="three wide column">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/admins/registrations/new.html.erb
+++ b/app/views/admins/registrations/new.html.erb
@@ -1,0 +1,49 @@
+<div class="ui container">
+  <div class="ui basic very padded segment">
+    <div class="ui grid">
+      <div class="row">
+        <div class="three wide column">
+        </div>
+        <div class="ten wide column">
+          <div class="ui segment">
+
+            <h2>Sign up</h2>
+
+            <%= form_for(resource, as: resource_name, url: registration_path(resource_name), :html => {:class => "ui form"}) do |f| %>
+              <%= devise_error_messages! %>
+
+              <div class="field">
+                <%= f.label :email %>
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password %>
+                <% if @minimum_password_length %>
+                  <em>(<%= @minimum_password_length %> characters minimum)</em>
+                <% end %>
+                <%= f.password_field :password, autocomplete: "off" %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password_confirmation %>
+                <%= f.password_field :password_confirmation, autocomplete: "off" %>
+              </div>
+
+              <div class="actions">
+                <%= f.submit "Sign up", :class => 'ui button' %>
+              </div>
+            <% end %>
+
+            <div class="ui floated horizontal list">
+              <%= render "admins/shared/links" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="three wide column">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -1,0 +1,47 @@
+<div class="ui container">
+  <div class="ui basic very padded segment">
+    <div class="ui grid">
+      <div class="row">
+        <div class="three wide column">
+        </div>
+        <div class="ten wide column">
+          <div class="ui segment">
+            <h2>Log in as an admin</h2>
+
+            <%= form_for(resource, as: resource_name, url: session_path(resource_name), :html => {:class => "ui form"}) do |f| %>
+              <div class="field">
+                <%= f.label :email %>
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password %>
+                <%= f.password_field :password, autocomplete: "off" %>
+              </div>
+
+              <% if devise_mapping.rememberable? -%>
+                <div class="field">
+                  <div class="ui checkbox">
+                    <%= f.check_box :remember_me %>
+                    <%= f.label :remember_me %>
+                  </div>
+                </div>
+              <% end -%>
+
+              <div class="actions">
+                <%= f.submit "Log in", :class => 'ui button' %>
+              </div>
+            <% end %>
+
+            <div class="ui floated horizontal list">
+              <%= render "admins/shared/links" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="three wide column">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admins/shared/_links.html.erb
+++ b/app/views/admins/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "item" %>
+  <% end -%>
+<% end -%>

--- a/app/views/admins/unlocks/new.html.erb
+++ b/app/views/admins/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "admins/shared/links" %>

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,4 +1,4 @@
 h1 Home#index
 p Find me in app/views/home/index.html.slim
+= link_to 'Sign out', destroy_user_session_path(:authenticity_token => form_authenticity_token()), method: :delete, class: "test"
 
-= javascript_pack_tag 'hello_react'

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/mailer/password_change.html.erb
+++ b/app/views/users/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/mailer/unlock_instructions.html.erb
+++ b/app/views/users/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,0 +1,37 @@
+<div class="ui container">
+  <div class="ui basic very padded segment">
+    <div class="ui grid">
+      <div class="row">
+        <div class="three wide column">
+        </div>
+        <div class="ten wide column">
+          <div class="ui segment">
+
+            <h2>Forgot your password?</h2>
+
+            <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, :class => "ui form" }) do |f| %>
+              <%= devise_error_messages! %>
+
+              <div class="field">
+                <%= f.label :email %>
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+
+              <div class="actions">
+                <%= f.submit "Send me reset password instructions", :class => 'ui button' %>
+              </div>
+            <% end %>
+
+            <div class="ui floated horizontal list">
+              <%= render "users/shared/links" %>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="three wide column">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,0 +1,49 @@
+<div class="ui container">
+  <div class="ui basic very padded segment">
+    <div class="ui grid">
+      <div class="row">
+        <div class="three wide column">
+        </div>
+        <div class="ten wide column">
+          <div class="ui segment">
+
+            <h2>Sign up</h2>
+
+            <%= form_for(resource, as: resource_name, url: registration_path(resource_name), :html => {:class => "ui form"}) do |f| %>
+              <%= devise_error_messages! %>
+
+              <div class="field">
+                <%= f.label :email %>
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password %>
+                <% if @minimum_password_length %>
+                  <em>(<%= @minimum_password_length %> characters minimum)</em>
+                <% end %>
+                <%= f.password_field :password, autocomplete: "off" %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password_confirmation %>
+                <%= f.password_field :password_confirmation, autocomplete: "off" %>
+              </div>
+
+              <div class="actions">
+                <%= f.submit "Sign up", :class => 'ui button' %>
+              </div>
+            <% end %>
+
+            <div class="ui floated horizontal list">
+              <%= render "users/shared/links" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="three wide column">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,47 @@
+<div class="ui container">
+  <div class="ui basic very padded segment">
+    <div class="ui grid">
+      <div class="row">
+        <div class="three wide column">
+        </div>
+        <div class="ten wide column">
+          <div class="ui segment">
+            <h2>Log in</h2>
+
+            <%= form_for(resource, as: resource_name, url: session_path(resource_name), :html => {:class => "ui form"}) do |f| %>
+              <div class="field">
+                <%= f.label :email %>
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password %>
+                <%= f.password_field :password, autocomplete: "off" %>
+              </div>
+
+              <% if devise_mapping.rememberable? -%>
+                <div class="field">
+                  <div class="ui checkbox">
+                    <%= f.check_box :remember_me %>
+                    <%= f.label :remember_me %>
+                  </div>
+                </div>
+              <% end -%>
+
+              <div class="actions">
+                <%= f.submit "Log in", :class => 'ui button' %>
+              </div>
+            <% end %>
+
+            <div class="ui floated horizontal list">
+              <%= render "users/shared/links" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="three wide column">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "item" %>
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "item" %>
+  <% end -%>
+<% end -%>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -220,7 +220,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-puts "============== Create addmin account ============"
+puts "============== Create admin account ============"
 
 admins = [
   # admin
@@ -75,3 +75,22 @@ end
   
 
 puts "============== Finished to create addmin account ============"
+
+puts "============== Create user account ============"
+
+users = [
+  # admin
+  {
+    email: 'user@test.com',
+    password: '1234qwer'
+  },
+]
+
+# Admin.destroy_all
+
+users.each do |user|
+  count = User.where(email: user[:email]).count
+  User.create(user) if count == 0
+end
+
+puts "============== Finished to create user account ============"

--- a/spec/controllers/admin/admins_controller_spec.rb
+++ b/spec/controllers/admin/admins_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Admin::AdminsController, type: :controller do
     end
 
     context "Email with incorrect format" do
-      it "returns success" do
+      it "returns failed" do
         post :create, admin: {
                email: "test2",
                password: "1234qwer",
@@ -50,6 +50,29 @@ RSpec.describe Admin::AdminsController, type: :controller do
                         "errors" => [{
                                        "reason" => "invalid",
                                        "message" => "Email format is invalid",
+                                       "location" => "email",
+                                       "location_type" => "field"
+                                     }]
+                      })
+        result = Admin.find_by_email("test2")
+        expect(result).to be_nil
+      end
+    end
+
+    context "Email is duplicated" do
+      let!(:admin_1) { create(:admin, email: "test@admin.com") }
+      it "returns failed" do
+        post :create, admin: {
+               email: "test@admin.com",
+               password: "1234qwer",
+               password_confirmation: "1234qwer"
+             }, format: :json
+        expect(response).to have_http_status(400)
+        expect(JSON.parse(response.body)["error"])
+          .to include({
+                        "errors" => [{
+                                       "reason" => "taken",
+                                       "message" => "Email has already been taken",
                                        "location" => "email",
                                        "location_type" => "field"
                                      }]


### PR DESCRIPTION
Sign in / sign out with devise for admins
 
add sign out button for react menu
run rails g devise:views admins for auto generating signup/signin views for admins
enable config.scoped_views to support custom devise views
update signup/signup views to follow semantic UI
customize devise helper to support parsing error message with '^' to cut subjects of messages.